### PR TITLE
algofoogle ring oscs: 'keep_hierarchy' on IHP instead of 'keep'

### DIFF
--- a/hdl/tt_um_algofoogle_tt09_ring_osc/docs/info.md
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc/docs/info.md
@@ -11,7 +11,7 @@ You can also include images in this folder and reference them in the markdown. E
 
 Everyone has done a ring oscillator using inverter cells. Now it's my turn!
 
-This simple example uses verilog to instantiate a ring of (an odd number of) `sky130_fd_sc_hd__inv_2` cells.
+This simple example uses Verilog to instantiate a ring of (an odd number of) `sky130_fd_sc_hd__inv_2` cells -- **UPDATE:** Actually, since this is targeting IHP instead, there is a polyfill that somebody else wrote to map sky130 cells to generic cells (that OpenLane will then map to IHP cells).
 
 It produces its output on `uo_out[0]`.
 

--- a/hdl/tt_um_algofoogle_tt09_ring_osc/src/project.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc/src/project.v
@@ -17,6 +17,7 @@ module tt_um_algofoogle_tt09_ring_osc (
 );
 
   ring_osc myring (
+    .ena(ena),
     .osc_out(uo_out[0])
   );
 

--- a/hdl/tt_um_algofoogle_tt09_ring_osc/src/ring_osc.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc/src/ring_osc.v
@@ -34,13 +34,14 @@ endmodule
 module ring_osc #(
     parameter DEPTH = 500 // Becomes DEPTH*2+1 inverters to ensure it is odd.
 ) (
+    input wire ena,
     output osc_out
 );
 
     wire [DEPTH*2:0] inv_in;
     wire [DEPTH*2:0] inv_out;
     assign inv_in[DEPTH*2:1] = inv_out[DEPTH*2-1:0]; // Chain.
-    assign inv_in[0] = inv_out[DEPTH*2]; // Loop back.
+    assign inv_in[0] = inv_out[DEPTH*2] & ena; // Loop back, unless disabled.
     // Generate an instance array of inverters, chained and looped back via the 2 assignments above:
     (* keep_hierarchy *) amm_inverter inv_array [DEPTH*2:0] ( .a(inv_in), .y(inv_out) );
     assign osc_out = inv_in[0];

--- a/hdl/tt_um_algofoogle_tt09_ring_osc/src/ring_osc.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc/src/ring_osc.v
@@ -24,7 +24,7 @@ module amm_inverter (
     output  wire y
 );
 
-    (* keep *) sky130_fd_sc_hd__inv_2   sky_inverter (
+    (* keep_hierarchy *) sky130_fd_sc_hd__inv_2   sky_inverter (
         .A  (a),
         .Y  (y)
     );
@@ -42,7 +42,7 @@ module ring_osc #(
     assign inv_in[DEPTH*2:1] = inv_out[DEPTH*2-1:0]; // Chain.
     assign inv_in[0] = inv_out[DEPTH*2]; // Loop back.
     // Generate an instance array of inverters, chained and looped back via the 2 assignments above:
-    (* keep *) amm_inverter inv_array [DEPTH*2:0] ( .a(inv_in), .y(inv_out) );
+    (* keep_hierarchy *) amm_inverter inv_array [DEPTH*2:0] ( .a(inv_in), .y(inv_out) );
     assign osc_out = inv_in[0];
 
 endmodule

--- a/hdl/tt_um_algofoogle_tt09_ring_osc2/docs/info.md
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc2/docs/info.md
@@ -22,5 +22,5 @@ I already submitted [tt09-ring-osc](https://github.com/algofoogle/tt09-ring-osc)
 
 Approximate frequences are estimated on the assumption that each inverter introduces a delay of ~70ps.
 
-These use verilog to instantiate the rings of (an odd number of) `sky130_fd_sc_hd__inv_2` cells.
+These use Verilog to instantiate the rings of (an odd number of) `sky130_fd_sc_hd__inv_2` cells -- **UPDATE:** Actually, since this is targeting IHP instead, there is a polyfill that somebody else wrote to map sky130 cells to generic cells (that OpenLane will then map to IHP cells).
 

--- a/hdl/tt_um_algofoogle_tt09_ring_osc2/src/project.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc2/src/project.v
@@ -18,13 +18,13 @@ module tt_um_algofoogle_tt09_ring_osc2 (
 
 
   // Ring of 125 inverters, output on uo_out[0] ~ 112MHz, if it makes it out?
-  ring_osc #(.DEPTH(62)) ring_125 (.osc_out(uo_out[0]));
+  ring_osc #(.DEPTH(62)) ring_125 (.ena(ena), .osc_out(uo_out[0]));
   // Ring of 251 inverters, output on uo_out[1] ~ 56MHz?
-  ring_osc #(.DEPTH(125)) ring_251 (.osc_out(uo_out[1]));
+  ring_osc #(.DEPTH(125)) ring_251 (.ena(ena), .osc_out(uo_out[1]));
   // Ring of 501 inverters, output on uo_out[2] ~ 28MHz?
-  ring_osc #(.DEPTH(250)) ring_501 (.osc_out(uo_out[2]));
+  ring_osc #(.DEPTH(250)) ring_501 (.ena(ena), .osc_out(uo_out[2]));
   // Ring of 1001 inverters, output on uo_out[3] ~ 14MHz?
-  ring_osc #(.DEPTH(500)) ring_1001 (.osc_out(uo_out[3]));
+  ring_osc #(.DEPTH(500)) ring_1001 (.ena(ena), .osc_out(uo_out[3]));
 
   // Clocking a simple counter as a clock divider for ring_501...
   // Naive, unless I configure CTS and SDC?
@@ -41,7 +41,7 @@ module tt_um_algofoogle_tt09_ring_osc2 (
 
   // Fast ring (25 inv) used for another counter experiment: ~570MHz?
   wire fast_osc;
-  ring_osc #(.DEPTH(12)) ring_25 (.osc_out(fast_osc));
+  ring_osc #(.DEPTH(12)) ring_25 (.ena(ena), .osc_out(fast_osc));
   // Counter to divide down to (hopefully) ~9MHz:
   reg [5:0] c2;
   always @(posedge fast_osc) c2 <= c2 + 1;

--- a/hdl/tt_um_algofoogle_tt09_ring_osc2/src/ring_osc.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc2/src/ring_osc.v
@@ -34,13 +34,14 @@ endmodule
 module ring_osc #(
     parameter DEPTH = 500 // Becomes DEPTH*2+1 inverters to ensure it is odd.
 ) (
+    input wire ena,
     output osc_out
 );
 
     wire [DEPTH*2:0] inv_in;
     wire [DEPTH*2:0] inv_out;
     assign inv_in[DEPTH*2:1] = inv_out[DEPTH*2-1:0]; // Chain.
-    assign inv_in[0] = inv_out[DEPTH*2]; // Loop back.
+    assign inv_in[0] = inv_out[DEPTH*2] & ena; // Loop back.
     // Generate an instance array of inverters, chained and looped back via the 2 assignments above:
     (* keep_hierarchy *) amm_inverter inv_array [DEPTH*2:0] ( .a(inv_in), .y(inv_out) );
     assign osc_out = inv_in[0];

--- a/hdl/tt_um_algofoogle_tt09_ring_osc2/src/ring_osc.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc2/src/ring_osc.v
@@ -24,7 +24,7 @@ module amm_inverter (
     output  wire y
 );
 
-    (* keep *) sky130_fd_sc_hd__inv_2   sky_inverter (
+    (* keep_hierarchy *) sky130_fd_sc_hd__inv_2   sky_inverter (
         .A  (a),
         .Y  (y)
     );
@@ -42,7 +42,7 @@ module ring_osc #(
     assign inv_in[DEPTH*2:1] = inv_out[DEPTH*2-1:0]; // Chain.
     assign inv_in[0] = inv_out[DEPTH*2]; // Loop back.
     // Generate an instance array of inverters, chained and looped back via the 2 assignments above:
-    (* keep *) amm_inverter inv_array [DEPTH*2:0] ( .a(inv_in), .y(inv_out) );
+    (* keep_hierarchy *) amm_inverter inv_array [DEPTH*2:0] ( .a(inv_in), .y(inv_out) );
     assign osc_out = inv_in[0];
 
 endmodule

--- a/hdl/tt_um_algofoogle_tt09_ring_osc3/docs/info.md
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc3/docs/info.md
@@ -13,5 +13,4 @@ See [tt09-ring-osc](https://github.com/algofoogle/tt09-ring-osc) and [tt09-ring-
 
 This one has a configurable ring oscillator; the feedback can be tapped at different parts of the chain.
 
-This use verilog to instantiate the rings of (an odd number of) `sky130_fd_sc_hd__inv_2` cells.
-
+This uses Verilog to instantiate a ring of (an odd number of) `sky130_fd_sc_hd__inv_2` cells -- **UPDATE:** Actually, since this is targeting IHP instead, there is a polyfill that somebody else wrote to map sky130 cells to generic cells (that OpenLane will then map to IHP cells).

--- a/hdl/tt_um_algofoogle_tt09_ring_osc3/src/config.json
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc3/src/config.json
@@ -16,8 +16,8 @@
   "PL_TARGET_DENSITY_PCT": 70,
 
   "//": "CLOCK_PERIOD - Increase this in case you are getting setup time violations.",
-  "//": "The value is in nanoseconds, so 20ns == 50MHz.",
-  "CLOCK_PERIOD": 20,
+  "//": "The value is in nanoseconds, so 100ns == 10MHz. It's fake here anyway; I don't use the clock.",
+  "CLOCK_PERIOD": 100,
 
   "//": "Hold slack margin - Increase them in case you are getting hold violations.",
   "PL_RESIZER_HOLD_SLACK_MARGIN": 0.1,

--- a/hdl/tt_um_algofoogle_tt09_ring_osc3/src/project.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc3/src/project.v
@@ -17,7 +17,7 @@ module tt_um_algofoogle_tt09_ring_osc3 (
 );
 
   wire osc;
-  tapped_ring tapped_ring ( .tap(ui_in[2:0]), .y(osc) );
+  tapped_ring tapped_ring ( .ena(ena), .tap(ui_in[2:0]), .y(osc) );
   assign uo_out[0] = osc;
   reg [6:0] count;
   always @(posedge osc) count <= count + 1;

--- a/hdl/tt_um_algofoogle_tt09_ring_osc3/src/ring_osc.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc3/src/ring_osc.v
@@ -49,6 +49,7 @@ module inv_chain #(
 endmodule
 
 module tapped_ring (
+    input wire ena,
     input [2:0] tap,
     output y
 );
@@ -70,5 +71,5 @@ module tapped_ring (
                 tap == 5 ?  b101:
                 tap == 6 ?  b301:
                 /*tap==7*/ b1001;
-    assign b0 = y;
+    assign b0 = y & ena;
 endmodule

--- a/hdl/tt_um_algofoogle_tt09_ring_osc3/src/ring_osc.v
+++ b/hdl/tt_um_algofoogle_tt09_ring_osc3/src/ring_osc.v
@@ -24,7 +24,7 @@ module amm_inverter (
     output  wire y
 );
 
-    (* keep *) sky130_fd_sc_hd__inv_2   sky_inverter (
+    (* keep_hierarchy *) sky130_fd_sc_hd__inv_2   sky_inverter (
         .A  (a),
         .Y  (y)
     );
@@ -44,7 +44,7 @@ module inv_chain #(
     assign ins[0] = a;
     assign ins[N-1:1] = outs[N-2:0];
     assign y = outs[N-1];
-    (* keep *) amm_inverter inv_array [N-1:0] ( .a(ins), .y(outs) );
+    (* keep_hierarchy *) amm_inverter inv_array [N-1:0] ( .a(ins), .y(outs) );
 
 endmodule
 
@@ -53,15 +53,15 @@ module tapped_ring (
     output y
 );
     wire b0, b1, b11, b21, b31, b41, b51, b101, b301, b1001;
-    (* keep *) amm_inverter      start ( .a(  b0), .y(     b1) ); // If all the counts below are even, this makes it odd.
-    (* keep *) inv_chain #(.N(10))  c0 ( .a(  b1), .y(    b11) );
-    (* keep *) inv_chain #(.N(10))  c1 ( .a( b11), .y(    b21) );
-    (* keep *) inv_chain #(.N(10))  c2 ( .a( b21), .y(    b31) );
-    (* keep *) inv_chain #(.N(10))  c3 ( .a( b31), .y(    b41) );
-    (* keep *) inv_chain #(.N(10))  c4 ( .a( b41), .y(    b51) );
-    (* keep *) inv_chain #(.N(50))  c5 ( .a( b51), .y(   b101) );
-    (* keep *) inv_chain #(.N(200)) c6 ( .a(b101), .y(   b301) );
-    (* keep *) inv_chain #(.N(700)) c7 ( .a(b301), .y(  b1001) );
+    (* keep_hierarchy *) amm_inverter      start ( .a(  b0), .y(     b1) ); // If all the counts below are even, this makes it odd.
+    (* keep_hierarchy *) inv_chain #(.N(10))  c0 ( .a(  b1), .y(    b11) );
+    (* keep_hierarchy *) inv_chain #(.N(10))  c1 ( .a( b11), .y(    b21) );
+    (* keep_hierarchy *) inv_chain #(.N(10))  c2 ( .a( b21), .y(    b31) );
+    (* keep_hierarchy *) inv_chain #(.N(10))  c3 ( .a( b31), .y(    b41) );
+    (* keep_hierarchy *) inv_chain #(.N(10))  c4 ( .a( b41), .y(    b51) );
+    (* keep_hierarchy *) inv_chain #(.N(50))  c5 ( .a( b51), .y(   b101) );
+    (* keep_hierarchy *) inv_chain #(.N(200)) c6 ( .a(b101), .y(   b301) );
+    (* keep_hierarchy *) inv_chain #(.N(700)) c7 ( .a(b301), .y(  b1001) );
     assign y =  tap == 0 ?   b11:
                 tap == 1 ?   b21:
                 tap == 2 ?   b31:


### PR DESCRIPTION
My 3 "ring_osc" tiles were being optimised out in the IHP flow, probably because of the sky130 standard cell polyfill. I found this out by looking at the GDS -- it was way too simple.

I replaced `(* keep *)` with `(* keep_hierarchy *)` and this seems to have fixed it; I was able to harden them individually and get a lot more cells as expected.

I did a minor doco update in this same PR.
